### PR TITLE
stac-fastapi.core-2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0/
 
 ### Added
 
+- Added option to include Basic Auth. [#12](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/12)
+
 ### Changed
 
+- Upgraded stac-fastapi.core to 2.2.0 [#15](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/15)
+
 ### Fixed
+
+- Added skip to basic_auth tests when `BASIC_AUTH` environment variable is not set
 
 
 ## [v3.0.1]
@@ -20,11 +26,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0/
 
 ### Changed
 
+- Removed bulk transactions extension from app.py
+
 ### Fixed
 
-- Removed bulk transactions extension from app.py
 - Fixed pagination issue with MongoDB. Fixes [#1](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/1)
-- Added option to include Basic Auth. [#12](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/12)
 
 
 ## [v3.0.0]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "stac-fastapi.core==2.1.0",
+    "stac-fastapi.core==2.2.0",
     "motor==3.3.2",
     "pymongo==4.6.2",
     "uvicorn",

--- a/stac_fastapi/tests/basic_auth/test_basic_auth.py
+++ b/stac_fastapi/tests/basic_auth/test_basic_auth.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 
 # - BASIC_AUTH={"public_endpoints":[{"path":"/","method":"GET"},{"path":"/search","method":"GET"}],"users":[{"username":"admin","password":"admin","permissions":"*"},{"username":"reader","password":"reader","permissions":[{"path":"/conformance","method":["GET"]},{"path":"/collections/{collection_id}/items/{item_id}","method":["GET"]},{"path":"/search","method":["POST"]},{"path":"/collections","method":["GET"]},{"path":"/collections/{collection_id}","method":["GET"]},{"path":"/collections/{collection_id}/items","method":["GET"]},{"path":"/queryables","method":["GET"]},{"path":"/queryables/collections/{collection_id}/queryables","method":["GET"]},{"path":"/_mgmt/ping","method":["GET"]}]}]}
 

--- a/stac_fastapi/tests/basic_auth/test_basic_auth.py
+++ b/stac_fastapi/tests/basic_auth/test_basic_auth.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 # - BASIC_AUTH={"public_endpoints":[{"path":"/","method":"GET"},{"path":"/search","method":"GET"}],"users":[{"username":"admin","password":"admin","permissions":"*"},{"username":"reader","password":"reader","permissions":[{"path":"/conformance","method":["GET"]},{"path":"/collections/{collection_id}/items/{item_id}","method":["GET"]},{"path":"/search","method":["POST"]},{"path":"/collections","method":["GET"]},{"path":"/collections/{collection_id}","method":["GET"]},{"path":"/collections/{collection_id}/items","method":["GET"]},{"path":"/queryables","method":["GET"]},{"path":"/queryables/collections/{collection_id}/queryables","method":["GET"]},{"path":"/_mgmt/ping","method":["GET"]}]}]}
 
@@ -6,6 +7,8 @@ import pytest
 @pytest.mark.asyncio
 async def test_get_search_not_authenticated(app_client_basic_auth):
     """Test public endpoint search without authentication"""
+    if not os.getenv("BASIC_AUTH"):
+        pytest.skip()
     params = {"query": '{"gsd": {"gt": 14}}'}
 
     response = await app_client_basic_auth.get("/search", params=params)
@@ -22,6 +25,8 @@ async def test_get_search_not_authenticated(app_client_basic_auth):
 @pytest.mark.asyncio
 async def test_post_search_authenticated(app_client_basic_auth):
     """Test protected post search with reader auhtentication"""
+    if not os.getenv("BASIC_AUTH"):
+        pytest.skip()
     params = {
         "bbox": [97.504892, -45.254738, 174.321298, -2.431580],
         "fields": {"exclude": ["properties"]},
@@ -42,6 +47,8 @@ async def test_post_search_authenticated(app_client_basic_auth):
 @pytest.mark.asyncio
 async def test_delete_resource_insufficient_permissions(app_client_basic_auth):
     """Test protected delete collection with reader auhtentication"""
+    if not os.getenv("BASIC_AUTH"):
+        pytest.skip()
     headers = {
         "Authorization": "Basic cmVhZGVyOnJlYWRlcg=="
     }  # Assuming this is a valid authorization token


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/15

**Description:**
Upgrade to stac-fastapi.core-2.2.0. Seems to fix the bug with the related issue. Tried to upgrade to 2.3.0 but encountered too many issues. Changes made to stac-fastapi.core affected all datetime related queries in [stac-fastapi-mongo](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo). Currently datetimes are stored as strings in MongoDB with the format provided by the users and this doesn't seem to work with the new update to stac-fastapi.core.

Also added some tweaks to the `basic_auth` tests so they are skipped when `BASIC_AUTH` environment variable is not set.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog