### PR TITLE
"stac-pydantic==3.0.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     "uvicorn",
     "starlette",
     "typing_extensions==4.8.0",
+    "stac-pydantic==3.0.0",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
**Description:**
`stac-fastapi.core==3.0.0a0` seems to be using the most recent version of `stac-pydantic`, which is version `3.1.0` released on May 21 (https://pypi.org/project/stac-pydantic/#history)

`stac-pydantic==3.1.0` seems to be breaking the tests of the repo, so for now I've added a `stac-pydantic==3.0.0` to `setup.py`.`install_requires`


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog