### PR TITLE
Fix for item ids being required to be unique across all collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0/
 - Add support for python 3.12. [#22](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/22)
 - Updated sfeos core to v3.0.0a0, fixed datetime functionality. [#23](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/23)
 
+### Fixed
+
+- Added a new index based on collection id and item id to ensure item IDs aren't required to be unique across all collections. [#26](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/26)
+
 
 ## [v3.2.1]
 

--- a/stac_fastapi/mongo/database_logic.py
+++ b/stac_fastapi/mongo/database_logic.py
@@ -691,7 +691,9 @@ class DatabaseLogic:
         mongo_item = self.item_serializer.stac_to_db(item, base_url)
 
         if not exist_ok:
-            existing_item = await items_collection.find_one({"id": mongo_item["id"]})
+            existing_item = await items_collection.find_one(
+                {"id": mongo_item["id"], "collection": mongo_item["collection"]}
+            )
             if existing_item:
                 raise ConflictError(
                     f"Item {mongo_item['id']} in collection {mongo_item['collection']} already exists"
@@ -733,7 +735,9 @@ class DatabaseLogic:
         mongo_item = self.item_serializer.stac_to_db(item, base_url)
 
         if not exist_ok:
-            existing_item = items_collection.find_one({"id": mongo_item["id"]})
+            existing_item = items_collection.find_one(
+                {"id": mongo_item["id"], "collection": mongo_item["collection"]}
+            )
             if existing_item:
                 raise ConflictError(
                     f"Item {mongo_item['id']} in collection {mongo_item['collection']} already exists"

--- a/stac_fastapi/mongo/database_logic.py
+++ b/stac_fastapi/mongo/database_logic.py
@@ -75,7 +75,7 @@ async def create_item_index():
         collection = db[ITEMS_INDEX]
         try:
             await collection.create_index([("properties.datetime", -1)])
-            await collection.create_index([("id", 1)], unique=True)
+            await collection.create_index([("collection", 1), ("id", 1)], unique=True)
             await collection.create_index([("geometry", "2dsphere")])
             print(f"Indexes created successfully for collection: {ITEMS_INDEX}.")
         except Exception as e:

--- a/stac_fastapi/mongo/database_logic.py
+++ b/stac_fastapi/mongo/database_logic.py
@@ -692,7 +692,7 @@ class DatabaseLogic:
 
         if not exist_ok:
             existing_item = await items_collection.find_one(
-                {"id": mongo_item["id"], "collection": mongo_item["collection"]}
+                {"collection": mongo_item["collection"], "id": mongo_item["id"]}
             )
             if existing_item:
                 raise ConflictError(
@@ -736,7 +736,7 @@ class DatabaseLogic:
 
         if not exist_ok:
             existing_item = items_collection.find_one(
-                {"id": mongo_item["id"], "collection": mongo_item["collection"]}
+                {"collection": mongo_item["collection"], "id": mongo_item["id"]}
             )
             if existing_item:
                 raise ConflictError(

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -34,7 +34,7 @@ database_logic = DatabaseLogic()
 
 
 @pytest.mark.asyncio
-async def test_create_and_delete_item(app_client, ctx, txn_client):
+async def test_create_item_indices(app_client, ctx, txn_client):
     """Test creation and deletion of a single item (transactions extension)"""
 
     test_item = ctx.item
@@ -890,3 +890,31 @@ async def test_search_datetime_validation_errors(app_client):
         # resp = await app_client.get("/search?datetime={}".format(dt))
         # assert resp.status_code == 400
         # updated for same reason as sfeos
+
+
+@pytest.mark.asyncio
+async def test_create_same_item_in_different_collections(
+    app_client, ctx, load_test_data
+):
+    """Test creation of items and indices"""
+
+    test_item = load_test_data("test_item.json")
+    test_collection = load_test_data("test_collection.json")
+
+    # create item in collection where an item with same id already exists
+    resp = await app_client.post(
+        f"/collections/{test_collection['id']}/items", json=test_item
+    )
+    assert resp.status_code == 409, resp.json()
+
+    # prep second collection
+    test_collection["id"] = "test_collection2"
+    resp = await app_client.post("/collections", json=test_collection)
+    assert resp.status_code == 201, resp.json()
+
+    # create item with same id in second collection
+    test_item["collection"] = test_collection["id"]
+    resp = await app_client.post(
+        f"/collections/{test_collection['id']}/items", json=test_item
+    )
+    assert resp.status_code == 201, resp.json()

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -34,7 +34,7 @@ database_logic = DatabaseLogic()
 
 
 @pytest.mark.asyncio
-async def test_create_item_indices(app_client, ctx, txn_client):
+async def test_create_and_delete_item(app_client, ctx, txn_client):
     """Test creation and deletion of a single item (transactions extension)"""
 
     test_item = ctx.item


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/25

**Description:**
Added a new index based on collection id and item id to ensure item IDs aren't required to be unique across all collections.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog