### PR TITLE
create indexes in MongoDB at startup only if env variable (default: true)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0/
 
 - Add support for python 3.12. [#22](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/22)
 - Updated sfeos core to v3.0.0a0, fixed datetime functionality. [#23](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/23)
+- Create indexes in MongoDB at startup only if environment variable MONGO_CREATE_INDEXES is set to "true" (default when the env variable is not set: "true"). [#31](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/31)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stac-fastapi-mongo
 
-## Mongo backend for the stac-fastapi project built on top of the [sfeos](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch) core api library. 
+## Mongo backend for the stac-fastapi project built on top of the [sfeos](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch) core api library.
 
 [![PyPI version](https://badge.fury.io/py/stac-fastapi.mongo.svg)](https://badge.fury.io/py/stac-fastapi.mongo)
 [![Join the chat at https://gitter.im/stac-fastapi-mongo/community](https://badges.gitter.im/stac-fastapi-mongo/community.svg)](https://gitter.im/stac-fastapi-mongo/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -39,7 +39,7 @@ pre-commit run --all-files
 docker-compose up mongo
 docker-compose build app-mongo
 ```
-  
+
 ## Running Mongo API on localhost:8084
 
 ```shell
@@ -56,15 +56,15 @@ curl -X "POST" "http://localhost:8084/collections" \
 }'
 ```
 
-Note: this "Collections Transaction" behavior is not part of the STAC API, but may be soon.  
+Note: this "Collections Transaction" behavior is not part of the STAC API, but may be soon.
 
 
 ## Collection pagination
 
 The collections route handles optional `limit` and `token` parameters. The `links` field that is
-returned from the `/collections` route contains a `next` link with the token that can be used to 
+returned from the `/collections` route contains a `next` link with the token that can be used to
 get the next page of results.
-   
+
 ```shell
 curl -X "GET" "http://localhost:8084/collections?limit=1&token=example_token"
 ```
@@ -160,3 +160,7 @@ Example: This example demonstrates the configuration for public endpoints, allow
 ### Basic Authentication Configurations
 
 See `docker-compose.basic_auth_protected.yml` and `docker-compose.basic_auth_public.yml` for basic authentication configurations.
+
+## Note for read-only databases
+
+If you are using a read-only MongoDB user, the `MONGO_CREATE_INDEXES` environment variable should be set to "false" (as a string and not a boolean) to avoid creating indexes in the database. When this environment variable is not set, the default is to create indexes. See [Github issue #28](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/28)

--- a/stac_fastapi/mongo/app.py
+++ b/stac_fastapi/mongo/app.py
@@ -1,5 +1,7 @@
 """FastAPI application."""
 
+import os
+
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
 from stac_fastapi.core.basic_auth import apply_basic_auth
@@ -77,8 +79,11 @@ apply_basic_auth(api)
 
 @app.on_event("startup")
 async def _startup_event() -> None:
-    await create_collection_index()
-    await create_item_index()
+    if (
+        os.getenv("MONGO_CREATE_INDEXES", "true") == "true"
+    ):  # Boolean env variables in docker compose are actually strings
+        await create_collection_index()
+        await create_item_index()
 
 
 def run() -> None:


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/28

**Description:**

Create indexes in MongoDB at startup only if environment variable `MONGO_CREATE_INDEXES` is set to "true" (default when the env variable is not set: "true")

**PR Checklist:**

- [👍] Code is formatted and linted (run `pre-commit run --all-files`)
- [ 👎] Tests pass (run `make test`) : see below
- [N/A] Documentation has been updated to reflect changes, if applicable
- [👍] Changes are added to the changelog

The `make test` doesn't pass, first because the test makefile is still using docker compose v1 syntax (`docker-compose`), so it returns a command not found error. I opened an issue for that: https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/30

Even after changing `docker-compose` to `docker compose`, the tests don't run successfully, see log below. As this PR only introduces a minor change, I guess this issue is rather due to the compose v1->v2 migration.

```
wait-for-it-es.sh: waiting 45 seconds for mongo:27017
wait-for-it-es.sh: timeout occurred after waiting 45 seconds for mongo:27017
make: [Makefile:51: test] Error 124 (ignored)
docker compose down
```