### PR TITLE
Filter by datetime objects instead of date strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0/
 
 - Add support for python 3.12. [#22](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/22)
 - Updated sfeos core to v3.0.0a0, fixed datetime functionality. [#23](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/23)
+- utilities.py/parse_datestring method now returns datetime and not str, otherwise time filtering does not work for MongoDB databases using datetime objects (which is recommended over using date strings). [#32](https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/32)
 
 ### Fixed
 

--- a/stac_fastapi/mongo/utilities.py
+++ b/stac_fastapi/mongo/utilities.py
@@ -1,7 +1,7 @@
 """utilities for stac-fastapi.mongo."""
 
 from base64 import urlsafe_b64decode, urlsafe_b64encode
-from datetime import timezone
+from datetime import datetime, timezone
 
 from bson import ObjectId
 from dateutil import parser  # type: ignore
@@ -32,7 +32,7 @@ def encode_token(token_value: str) -> str:
     return encoded_token
 
 
-def parse_datestring(dt_str: str) -> str:
+def parse_datestring(dt_str: str) -> datetime:
     """
     Normalize various ISO 8601 datetime formats to a consistent format.
 
@@ -45,8 +45,5 @@ def parse_datestring(dt_str: str) -> str:
     # Parse the datetime string to datetime object
     dt = parser.isoparse(dt_str)
 
-    # Convert the datetime to UTC and remove microseconds
-    dt = dt.astimezone(timezone.utc).replace(microsecond=0)
-
-    # Format the datetime to the specified format
-    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Convert the datetime to UTC
+    return dt.astimezone(timezone.utc)


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/29

**Description:**

utilities.py/parse_datestring method now returns datetime and not str, otherwise time filtering does not work for MongoDB databases using datetime objects (which is recommended over using date strings)

**PR Checklist:**

- [ 👍] Code is formatted and linted (run `pre-commit run --all-files`)
- [👎 ] Tests pass (run `make test`): no, for the same reason as in https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/pull/31
- [ N/A] Documentation has been updated to reflect changes, if applicable
- [👍 ] Changes are added to the changelog